### PR TITLE
feat: create form of Google Book API Key

### DIFF
--- a/src/apis/base_api.ts
+++ b/src/apis/base_api.ts
@@ -11,7 +11,7 @@ export interface BaseBooksApiImpl {
 
 export function factoryServiceProvider(settings: BookSearchPluginSettings): BaseBooksApiImpl {
   if (settings.serviceProvider === ServiceProvider.google) {
-    return new GoogleBooksApi(settings.localePreference);
+    return new GoogleBooksApi(settings.localePreference, settings.apiKey);
   }
   if (settings.serviceProvider === ServiceProvider.naver) {
     if (!settings.naverClientId || !settings.naverClientSecret) {

--- a/src/apis/google_books_api.ts
+++ b/src/apis/google_books_api.ts
@@ -3,7 +3,7 @@ import { apiGet, BaseBooksApiImpl } from '@apis/base_api';
 import { GoogleBooksResponse, VolumeInfo } from './models/google_books_response';
 
 export class GoogleBooksApi implements BaseBooksApiImpl {
-  constructor(private readonly localePreference: string) {}
+  constructor(private readonly localePreference: string, private readonly apiKey?: string) {}
 
   async getByQuery(query: string) {
     try {
@@ -17,6 +17,9 @@ export class GoogleBooksApi implements BaseBooksApiImpl {
         params['langRestrict'] = window.moment.locale();
       } else {
         params['langRestrict'] = langRestrict;
+      }
+      if (this.apiKey !== '') {
+        params['key'] = this.apiKey;
       }
       const searchResults = await apiGet<GoogleBooksResponse>('https://www.googleapis.com/books/v1/volumes', params);
       if (!searchResults?.totalItems) {

--- a/src/apis/google_books_api.ts
+++ b/src/apis/google_books_api.ts
@@ -2,6 +2,12 @@ import { Book } from '@models/book.model';
 import { apiGet, BaseBooksApiImpl } from '@apis/base_api';
 import { GoogleBooksResponse, VolumeInfo } from './models/google_books_response';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Electron = require('electron');
+const {
+  remote: { safeStorage },
+} = Electron;
+
 export class GoogleBooksApi implements BaseBooksApiImpl {
   constructor(private readonly localePreference: string, private readonly apiKey?: string) {}
 
@@ -19,7 +25,7 @@ export class GoogleBooksApi implements BaseBooksApiImpl {
         params['langRestrict'] = langRestrict;
       }
       if (this.apiKey !== '') {
-        params['key'] = this.apiKey;
+        params['key'] = safeStorage.isEncryptionAvailable() ? safeStorage.decryptString(this.apiKey) : this.apiKey;
       }
       const searchResults = await apiGet<GoogleBooksResponse>('https://www.googleapis.com/books/v1/volumes', params);
       if (!searchResults?.totalItems) {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,6 +1,11 @@
 import { App, PluginSettingTab, Setting } from 'obsidian';
 import { replaceDateInString } from '@utils/utils';
 
+//const Electron = require('electron');
+//const {
+//  remote: { safeStorage },
+//} = Electron;
+
 import BookSearchPlugin from '../main';
 import { FileNameFormatSuggest } from './suggesters/FileNameFormatSuggester';
 import { FolderSuggest } from './suggesters/FolderSuggester';
@@ -27,6 +32,7 @@ export interface BookSearchPluginSettings {
   naverClientId: string;
   naverClientSecret: string;
   localePreference: string;
+  apiKey: string;
 }
 
 export const DEFAULT_SETTINGS: BookSearchPluginSettings = {
@@ -41,6 +47,7 @@ export const DEFAULT_SETTINGS: BookSearchPluginSettings = {
   naverClientId: '',
   naverClientSecret: '',
   localePreference: 'default',
+  apiKey: '',
 };
 
 export class BookSearchSettingTab extends PluginSettingTab {
@@ -261,6 +268,25 @@ export class BookSearchSettingTab extends PluginSettingTab {
           textArea.setValue(prevValue).onChange(async value => {
             const newValue = value;
             this.plugin.settings.content = newValue;
+            await this.plugin.saveSettings();
+          });
+        }),
+    );
+
+    // API Settings
+    //
+    // TODO: More Secure Saveing System
+    const APISettingsChildren: Setting[] = [];
+    createFoldingHeader(containerEl, 'API Settings', APISettingsChildren);
+    APISettingsChildren.push(
+      new Setting(containerEl)
+        .setName('Google Book API Key')
+        .setDesc('Be secure the API key.\n How the API create, please read README')
+        .addText(text => {
+          const prevValue = this.plugin.settings.apiKey;
+          text.setValue(prevValue).onChange(async value => {
+            const newValue = value;
+            this.plugin.settings.apiKey = newValue;
             await this.plugin.saveSettings();
           });
         }),

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -275,15 +275,16 @@ export class BookSearchSettingTab extends PluginSettingTab {
     );
 
     // API Settings
-    //
-    // TODO: More Secure Saveing System
     const APISettingsChildren: Setting[] = [];
-    createFoldingHeader(containerEl, 'API Settings', APISettingsChildren);
+    createFoldingHeader(containerEl, 'Google API Settings', APISettingsChildren);
     let tempKeyValue = '';
     APISettingsChildren.push(
       new Setting(containerEl)
+        .setClass('book-search-plugin__hide')
         .setName('Google Book API Key')
-        .setDesc('Be secure the API key.\n How the API create, please read README')
+        .setDesc(
+          'Add your Books API key. **WARNING** please use this field after you must understand Google Cloud API, such as API key security.',
+        )
         .addText(text => {
           text.onChange(async value => {
             if (safeStorage.isEncryptionAvailable()) {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,10 +1,11 @@
-import { App, PluginSettingTab, Setting } from 'obsidian';
+import { App, PluginSettingTab, Setting, Notice } from 'obsidian';
 import { replaceDateInString } from '@utils/utils';
 
-//const Electron = require('electron');
-//const {
-//  remote: { safeStorage },
-//} = Electron;
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Electron = require('electron');
+const {
+  remote: { safeStorage },
+} = Electron;
 
 import BookSearchPlugin from '../main';
 import { FileNameFormatSuggest } from './suggesters/FileNameFormatSuggester';
@@ -278,16 +279,25 @@ export class BookSearchSettingTab extends PluginSettingTab {
     // TODO: More Secure Saveing System
     const APISettingsChildren: Setting[] = [];
     createFoldingHeader(containerEl, 'API Settings', APISettingsChildren);
+    let tempKeyValue = '';
     APISettingsChildren.push(
       new Setting(containerEl)
         .setName('Google Book API Key')
         .setDesc('Be secure the API key.\n How the API create, please read README')
         .addText(text => {
-          const prevValue = this.plugin.settings.apiKey;
-          text.setValue(prevValue).onChange(async value => {
-            const newValue = value;
-            this.plugin.settings.apiKey = newValue;
+          text.onChange(async value => {
+            if (safeStorage.isEncryptionAvailable()) {
+              tempKeyValue = safeStorage.enctyptString(value);
+            } else {
+              tempKeyValue = value;
+            }
+          });
+        })
+        .addButton(button => {
+          button.setButtonText('Save Key').onClick(async () => {
+            this.plugin.settings.apiKey = tempKeyValue;
             await this.plugin.saveSettings();
+            new Notice('Apikey Saved');
           });
         }),
     );


### PR DESCRIPTION
## Feature
- Seatch with my Google Book API with safe-storage
- Add Google Search API text input in settings page

## Ref
#73 
https://github.com/anpigon/obsidian-book-search-plugin/issues/73#issuecomment-1722158947

## Random
I think this option is difficult to normal user because it should be carefully use Google Cloud API. So be careful to apply this feature.

I don't know to import electron with type of ES Module, so I used ts-ignore. If someone have a solution, it may be apply this.

Action failed but I don't know how to resolve.
```
request to https://api.codeball.ai/jobs failed, reason: getaddrinfo EAI_AGAIN api.codeball.ai
```