### PR TITLE
Feature: Displaying Cover Images in Search Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ You can set the template file location. There is an example template at the bott
 You can set up the services that you use to search for books. Only Google and Naver(네이버) are available now.
 To use Naver Book Search, clientId and clientSecret are required. I will explain how to get clientId and clientSecret from Naver on my blog.
 
+### Cover Image Saving
+
+### Cover Image Saving
+
+This feature allows for the automatic downloading and saving of book cover images directly into your Obsidian vault.
+By default, this option is turned off and can be activated in the plugin settings.
+Upon enabling, you can designate a specific folder within your vault for storing these images, streamlining the management of book cover resources within your notes.
+To include these images in your notes, use the `{{localCoverImage}}` Templater variable.
+
 ### <strike>(Deprecated) Text to insert into front matter</strike>
 
 <strike>You can add the following to the default Front Matter, or create a new Front Matter with the structure you want.</strike> Please use the template file described below.
@@ -222,6 +231,7 @@ Please find here a definition of the possible variables to be used in your templ
 | publishDate | The year the book was published.                        |
 | isbn10      | ISBN10                                                  |
 | isbn13      | ISBN13                                                  |
+| localCoverImage| Local path of the downloaded cover image.                |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -44,33 +44,50 @@ Or, Search in the Obsidian Community plugin. And install it.
 
 <img width="700" src="https://user-images.githubusercontent.com/3969643/184918934-585375a9-7b25-4905-81c8-5f092ed74991.png">
 
-<br>
+### Enhancements: Cover Image Display in Search Results
 
-### Styling Updates for Book Suggestions
+We've introduced a new setting in our plugin that allows users to display cover images alongside book suggestions in the search results. This feature aims to enrich the search experience by providing visual cues, making it easier for users to identify books at a glance. The cover images are designed to complement the textual information, offering a more engaging and intuitive search interface.
 
-To enhance the visual presentation of the book suggestions, we've added a small CSS snippet that ensures book cover images are displayed alongside the book's details. This update improves the user's ability to quickly scan and identify books based on their covers.
+By default, this feature is **disabled** to maintain a clean, text-focused search experience. Users who prefer to keep their search results streamlined without images will find the default setting optimized for their preference.
 
-Here is the CSS snippet that has been added:
+#### Enabling Cover Images
+
+To activate cover images in your search results:
+
+1. Go to the plugin settings.
+2. Find the **"Show Cover Images in Search"** option.
+3. Switch the toggle to **on** to enable cover images.
+
+#### CSS Styling for Cover Images
+
+For those who enable this feature, we've added CSS styling to ensure that cover images are displayed effectively without disrupting the flow of information. To add this CSS snippet in Obsidian, you can either include it directly in your plugin's CSS file or insert it into Obsidian's custom CSS section for your vault. Here's how to add the CSS snippet for styling the book suggestions with cover images:
+1. Open Obsidian.
+2. Navigate to Settings > Appearance.
+3. Under the CSS Snippets section, click on Open snippets folder.
+4. Create a new .css file in this folder and paste the following CSS snippet into the file.
+5. Go back to Obsidian, and under CSS Snippets, turn on the snippet you just added.
 
 ```css
 .book-suggestion-item {
   display: flex;
   align-items: center;
-  margin-bottom: 10px; /* Adjust spacing between items */
+  margin-bottom: 10px;
 }
 
 .book-cover-image {
   max-width: 100px;
   max-height: 100px;
-  margin-right: 10px; /* Spacing between image and text */
-  object-fit: cover; /* Ensures the image covers the area, might clip the image */
-  border-radius: 3px; /* Optional: rounds the corners of the image */
+  margin-right: 10px;
+  object-fit: cover;
+  border-radius: 3px;
 }
 
 .book-text-info {
   flex-grow: 1;
 }
 ```
+
+<br>
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,32 @@ Or, Search in the Obsidian Community plugin. And install it.
 
 <br>
 
+### Styling Updates for Book Suggestions
+
+To enhance the visual presentation of the book suggestions, we've added a small CSS snippet that ensures book cover images are displayed alongside the book's details. This update improves the user's ability to quickly scan and identify books based on their covers.
+
+Here is the CSS snippet that has been added:
+
+```css
+.book-suggestion-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px; /* Adjust spacing between items */
+}
+
+.book-cover-image {
+  max-width: 100px;
+  max-height: 100px;
+  margin-right: 10px; /* Spacing between image and text */
+  object-fit: cover; /* Ensures the image covers the area, might clip the image */
+  border-radius: 3px; /* Optional: rounds the corners of the image */
+}
+
+.book-text-info {
+  flex-grow: 1;
+}
+```
+
 ## How to use
 
 ### 1. Click the ribbon icon, or excute the command "Create new book note".

--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ To use Naver Book Search, clientId and clientSecret are required. I will explain
 
 ### Cover Image Saving
 
-### Cover Image Saving
-
 This feature allows for the automatic downloading and saving of book cover images directly into your Obsidian vault.
 By default, this option is turned off and can be activated in the plugin settings.
 Upon enabling, you can designate a specific folder within your vault for storing these images, streamlining the management of book cover resources within your notes.

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,7 +155,7 @@ export default class BookSearchPlugin extends Plugin {
 
   async openBookSuggestModal(books: Book[]): Promise<Book> {
     return new Promise((resolve, reject) => {
-      return new BookSuggestModal(this.app, books, (error, selectedBook) => {
+      return new BookSuggestModal(this.app, this.settings.showCoverImageInSearch, books, (error, selectedBook) => {
         return error ? reject(error) : resolve(selectedBook);
       }).open();
     });

--- a/src/models/book.model.ts
+++ b/src/models/book.model.ts
@@ -15,6 +15,7 @@ export interface Book {
   coverSmallUrl?: string; // 커버 URL
   coverMediumUrl?: string; // 커버 URL
   coverLargeUrl?: string; // 커버 URL
+  localCoverImage?: string;
   status?: string; // 읽기 상태(읽기전, 읽는중, 읽기완료)
   startReadDate?: string; // 읽기 시작한 일시
   finishReadDate?: string; // 읽기 완료한 일시

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -31,6 +31,7 @@ export interface BookSearchPluginSettings {
   localePreference: string;
   apiKey: string;
   openPageOnCompletion: boolean;
+  showCoverImageInSearch: boolean;
 }
 
 export const DEFAULT_SETTINGS: BookSearchPluginSettings = {
@@ -47,6 +48,7 @@ export const DEFAULT_SETTINGS: BookSearchPluginSettings = {
   localePreference: 'default',
   apiKey: '',
   openPageOnCompletion: true,
+  showCoverImageInSearch: false,
 };
 
 export class BookSearchSettingTab extends PluginSettingTab {
@@ -218,6 +220,16 @@ export class BookSearchSettingTab extends PluginSettingTab {
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.openPageOnCompletion).onChange(async value => {
           this.plugin.settings.openPageOnCompletion = value;
+          await this.plugin.saveSettings();
+        }),
+      );
+
+    new Setting(containerEl)
+      .setName('Show Cover Images in Search')
+      .setDesc('Toggle to show or hide cover images in the search results.')
+      .addToggle(toggle =>
+        toggle.setValue(this.plugin.settings.showCoverImageInSearch).onChange(async value => {
+          this.plugin.settings.showCoverImageInSearch = value;
           await this.plugin.saveSettings();
         }),
       );

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -32,6 +32,8 @@ export interface BookSearchPluginSettings {
   apiKey: string;
   openPageOnCompletion: boolean;
   showCoverImageInSearch: boolean;
+  enableCoverImageSave: boolean;
+  coverImagePath: string;
 }
 
 export const DEFAULT_SETTINGS: BookSearchPluginSettings = {
@@ -49,6 +51,8 @@ export const DEFAULT_SETTINGS: BookSearchPluginSettings = {
   apiKey: '',
   openPageOnCompletion: true,
   showCoverImageInSearch: false,
+  enableCoverImageSave: false,
+  coverImagePath: '',
 };
 
 export class BookSearchSettingTab extends PluginSettingTab {
@@ -233,6 +237,33 @@ export class BookSearchSettingTab extends PluginSettingTab {
           await this.plugin.saveSettings();
         }),
       );
+
+    new Setting(containerEl)
+      .setName('Enable Cover Image Save')
+      .setDesc('Toggle to enable or disable saving cover images in notes.')
+      .addToggle(toggle =>
+        toggle.setValue(this.plugin.settings.enableCoverImageSave).onChange(async value => {
+          this.plugin.settings.enableCoverImageSave = value;
+          await this.plugin.saveSettings();
+        }),
+      );
+
+    new Setting(containerEl)
+      .setName('Cover Image Path')
+      .setDesc('Specify the path where cover images should be saved.')
+      .addSearch(cb => {
+        try {
+          new FolderSuggest(this.app, cb.inputEl);
+        } catch {
+          // eslint-disable
+        }
+        cb.setPlaceholder('Enter the path (e.g., Images/Covers)')
+          .setValue(this.plugin.settings.coverImagePath)
+          .onChange(async value => {
+            this.plugin.settings.coverImagePath = value.trim();
+            await this.plugin.saveSettings();
+          });
+      });
 
     // Frontmatter Settings
     const formatterSettingsChildren: Setting[] = [];

--- a/src/views/book_suggest_modal.ts
+++ b/src/views/book_suggest_modal.ts
@@ -2,12 +2,16 @@ import { App, SuggestModal } from 'obsidian';
 import { Book } from '@models/book.model';
 
 export class BookSuggestModal extends SuggestModal<Book> {
+  showCoverImageInSearch: boolean;
+
   constructor(
     app: App,
+    showCoverImageInSearch: boolean,
     private readonly suggestion: Book[],
     private onChoose: (error: Error | null, result?: Book) => void,
   ) {
     super(app);
+    this.showCoverImageInSearch = showCoverImageInSearch;
   }
 
   // Returns all available suggestions.
@@ -28,7 +32,7 @@ export class BookSuggestModal extends SuggestModal<Book> {
 
     const coverImageUrl = book.coverLargeUrl || book.coverMediumUrl || book.coverSmallUrl || book.coverUrl;
 
-    if (coverImageUrl) {
+    if (this.showCoverImageInSearch && coverImageUrl) {
       const imgEl = el.createEl('img', {
         cls: 'book-cover-image',
         attr: {

--- a/src/views/book_suggest_modal.ts
+++ b/src/views/book_suggest_modal.ts
@@ -24,13 +24,32 @@ export class BookSuggestModal extends SuggestModal<Book> {
 
   // Renders each suggestion item.
   renderSuggestion(book: Book, el: HTMLElement) {
-    const title = book.title;
+    el.addClass('book-suggestion-item');
+
+    const coverImageUrl = book.coverLargeUrl || book.coverMediumUrl || book.coverSmallUrl || book.coverUrl;
+
+    if (coverImageUrl) {
+      const imgEl = el.createEl('img', {
+        cls: 'book-cover-image',
+        attr: {
+          src: coverImageUrl,
+          alt: `Cover Image for ${book.title}`,
+        },
+      });
+      imgEl.style.maxWidth = '100px';
+      imgEl.style.maxHeight = '100px';
+      imgEl.style.marginRight = '10px';
+      imgEl.style.float = 'left';
+    }
+
+    const textContainer = el.createEl('div', { cls: 'book-text-info' });
+    textContainer.createEl('div', { text: book.title });
+
     const publisher = book.publisher ? `, ${book.publisher}` : '';
     const publishDate = book.publishDate ? `(${book.publishDate})` : '';
     const totalPage = book.totalPage ? `, p${book.totalPage}` : '';
     const subtitle = `${book.author}${publisher}${publishDate}${totalPage}`;
-    el.createEl('div', { text: title });
-    el.createEl('small', { text: subtitle });
+    textContainer.createEl('small', { text: subtitle });
   }
 
   // Perform action on the selected suggestion.


### PR DESCRIPTION
Implemented a new setting allowing users to enable or disable the display of cover images in the search results. This enhancement aims to provide a more visually engaging search experience, helping users quickly identify books by their covers. The feature is off by default, ensuring a seamless integration for users preferring text-only search results. Additionally, CSS styling has been added to ensure that, when enabled, cover images are displayed effectively without disrupting the flow of information.

This update includes:
- A toggle in the plugin settings for showing cover images.
- CSS styling for integrating cover images with book suggestions.

This feature enhances the plugin's usability and provides users with the flexibility to customize their search experience according to their preferences.

Example
![grafik](https://github.com/anpigon/obsidian-book-search-plugin/assets/77202149/9aa4acea-a0bb-4ed1-8484-cd448578b77c)
