### PR TITLE
Save cover image locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ You can set the template file location. There is an example template at the bott
 You can set up the services that you use to search for books. Only Google and Naver(네이버) are available now.
 To use Naver Book Search, clientId and clientSecret are required. I will explain how to get clientId and clientSecret from Naver on my blog.
 
+### Cover Image Saving
+
+This feature allows for the automatic downloading and saving of book cover images directly into your Obsidian vault.
+By default, this option is turned off and can be activated in the plugin settings.
+Upon enabling, you can designate a specific folder within your vault for storing these images.
+
+
 ### <strike>(Deprecated) Text to insert into front matter</strike>
 
 <strike>You can add the following to the default Front Matter, or create a new Front Matter with the structure you want.</strike> Please use the template file described below.

--- a/README.md
+++ b/README.md
@@ -90,10 +90,12 @@ To use Naver Book Search, clientId and clientSecret are required. I will explain
 
 ### Cover Image Saving
 
+### Cover Image Saving
+
 This feature allows for the automatic downloading and saving of book cover images directly into your Obsidian vault.
 By default, this option is turned off and can be activated in the plugin settings.
-Upon enabling, you can designate a specific folder within your vault for storing these images.
-
+Upon enabling, you can designate a specific folder within your vault for storing these images, streamlining the management of book cover resources within your notes.
+To include these images in your notes, use the `{{localCoverImage}}` Templater variable.
 
 ### <strike>(Deprecated) Text to insert into front matter</strike>
 
@@ -186,6 +188,7 @@ Please find here a definition of the possible variables to be used in your templ
 | publishDate | The year the book was published.                        |
 | isbn10      | ISBN10                                                  |
 | isbn13      | ISBN13                                                  |
+| localCoverImage| Local path of the downloaded cover image.                |
 
 <br>
 

--- a/src/models/book.model.ts
+++ b/src/models/book.model.ts
@@ -15,6 +15,7 @@ export interface Book {
   coverSmallUrl?: string; // 커버 URL
   coverMediumUrl?: string; // 커버 URL
   coverLargeUrl?: string; // 커버 URL
+  localCoverImage?: string;
   status?: string; // 읽기 상태(읽기전, 읽는중, 읽기완료)
   startReadDate?: string; // 읽기 시작한 일시
   finishReadDate?: string; // 읽기 완료한 일시

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -31,6 +31,8 @@ export interface BookSearchPluginSettings {
   localePreference: string;
   apiKey: string;
   openPageOnCompletion: boolean;
+  enableCoverImageSave: boolean;
+  coverImagePath: string;
 }
 
 export const DEFAULT_SETTINGS: BookSearchPluginSettings = {
@@ -47,6 +49,8 @@ export const DEFAULT_SETTINGS: BookSearchPluginSettings = {
   localePreference: 'default',
   apiKey: '',
   openPageOnCompletion: true,
+  enableCoverImageSave: false,
+  coverImagePath: '',
 };
 
 export class BookSearchSettingTab extends PluginSettingTab {
@@ -221,6 +225,33 @@ export class BookSearchSettingTab extends PluginSettingTab {
           await this.plugin.saveSettings();
         }),
       );
+
+    new Setting(containerEl)
+      .setName('Enable Cover Image Save')
+      .setDesc('Toggle to enable or disable saving cover images in notes.')
+      .addToggle(toggle =>
+        toggle.setValue(this.plugin.settings.enableCoverImageSave).onChange(async value => {
+          this.plugin.settings.enableCoverImageSave = value;
+          await this.plugin.saveSettings();
+        }),
+      );
+
+    new Setting(containerEl)
+      .setName('Cover Image Path')
+      .setDesc('Specify the path where cover images should be saved.')
+      .addSearch(cb => {
+        try {
+          new FolderSuggest(this.app, cb.inputEl);
+        } catch {
+          // eslint-disable
+        }
+        cb.setPlaceholder('Enter the path (e.g., Images/Covers)')
+          .setValue(this.plugin.settings.coverImagePath)
+          .onChange(async value => {
+            this.plugin.settings.coverImagePath = value.trim();
+            await this.plugin.saveSettings();
+          });
+      });
 
     // Frontmatter Settings
     const formatterSettingsChildren: Setting[] = [];


### PR DESCRIPTION
This feature allows for the automatic downloading and saving of book cover images directly into your Obsidian vault.
By default, this option is turned off and can be activated in the plugin settings.
Upon enabling, you can designate a specific folder within your vault for storing these images, streamlining the management of book cover resources within your notes.
To include these images in your notes, use the {{localCoverImage}} Templater variable.