### PR TITLE
Add toggle to keep/remove the locale dropdown in the search modal

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -33,6 +33,7 @@ export interface BookSearchPluginSettings {
   showCoverImageInSearch: boolean;
   enableCoverImageSave: boolean;
   coverImagePath: string;
+  askForLocale: boolean;
 }
 
 export const DEFAULT_SETTINGS: BookSearchPluginSettings = {
@@ -52,6 +53,7 @@ export const DEFAULT_SETTINGS: BookSearchPluginSettings = {
   showCoverImageInSearch: false,
   enableCoverImageSave: false,
   coverImagePath: '',
+  askForLocale: true,
 };
 
 export class BookSearchSettingTab extends PluginSettingTab {
@@ -280,6 +282,17 @@ export class BookSearchSettingTab extends PluginSettingTab {
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.showCoverImageInSearch).onChange(async value => {
           this.plugin.settings.showCoverImageInSearch = value;
+          await this.plugin.saveSettings();
+        }),
+      );
+
+    // A toggle whether or not to ask for the locale every time a search is made
+    new Setting(containerEl)
+      .setName('Ask for Locale')
+      .setDesc('Toggle to enable or disable asking for the locale every time a search is made.')
+      .addToggle(toggle =>
+        toggle.setValue(this.plugin.settings.askForLocale).onChange(async value => {
+          this.plugin.settings.askForLocale = value;
           await this.plugin.saveSettings();
         }),
       );

--- a/src/views/book_search_modal.ts
+++ b/src/views/book_search_modal.ts
@@ -49,7 +49,8 @@ export class BookSearchModal extends Modal {
   onOpen(): void {
     const { contentEl } = this;
     contentEl.createEl('h2', { text: 'Search Book' });
-    if (this.plugin.settings.serviceProvider === ServiceProvider.google) this.renderSelectLocale();
+    if (this.plugin.settings.serviceProvider === ServiceProvider.google && this.plugin.settings.askForLocale)
+      this.renderSelectLocale();
     contentEl.createDiv({ cls: 'book-search-plugin__search-modal--input' }, el => {
       new TextComponent(el)
         .setValue(this.query)


### PR DESCRIPTION
Fixes #99 

A lot of people (at least me) only ever search within one locale, so having locale as an option every search doesn't make sense. 

I've left the existing behavior as the default behavior, but added a toggle to enable using the default locale always.