### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,16 +150,17 @@ publish: {{publishDate}}
 total: {{totalPage}}
 isbn: {{isbn10}} {{isbn13}}
 cover: {{coverUrl}}
+localCover: {{localCoverImage}}
 status: unread
 created: {{DATE:YYYY-MM-DD HH:mm:ss}}
 updated: {{DATE:YYYY-MM-DD HH:mm:ss}}
 ---
 
 %% To use an image URL from the server, use the following syntax: %%
-![cover|150]({{coverUrl}})
+<%* if (tp.frontmatter.cover && tp.frontmatter.cover.trim() !== "") { tR += `![cover|150](${tp.frontmatter.cover})` } %>
 
 %% To save images locally, enable the 'Enable Cover Image Save' option in the settings and enter as follows: %%
-![[{{localCoverImage}}|150]]
+<%* if (tp.frontmatter.localCover && tp.frontmatter.localCover.trim() !== "") { tR += `![[${tp.frontmatter.localCover}|150]]` } %>
 
 # {{title}}
 


### PR DESCRIPTION
Checking, if cover or localCover is set before referencing for robustness. Because some books do not have cover images on google books and that resulted in reference-errors in the book-notes. Tested it locally for me. Feel free to test & correct.