### PR TITLE
feat: add cover image edge curl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ You can set the template file location. There is an example template at the bott
 You can set up the services that you use to search for books. Only Google and Naver(네이버) are available now.
 To use Naver Book Search, clientId and clientSecret are required. I will explain how to get clientId and clientSecret from Naver on my blog.
 
+### Cover Image Edge Curl
+
+By default, the Google Books API adds a "page curl" effect to image thumbnails. Disabling this toggle will remove this effect from the cover images.
+
 ### Cover Image Saving
 
 This feature allows for the automatic downloading and saving of book cover images directly into your Obsidian vault.
@@ -284,7 +288,6 @@ published_at: <%= book.publishDate.substring(0, 4) %>
 ```
 published_at: <%= book.publishDate.replace(/-/g,'') %>
 ```
-
 
 <br>
 

--- a/src/apis/base_api.ts
+++ b/src/apis/base_api.ts
@@ -19,7 +19,7 @@ class ConfigurationError extends Error {
 export function factoryServiceProvider(settings: BookSearchPluginSettings): BaseBooksApiImpl {
   switch (settings.serviceProvider) {
     case ServiceProvider.google:
-      return new GoogleBooksApi(settings.localePreference, settings.apiKey);
+      return new GoogleBooksApi(settings.localePreference, settings.enableCoverImageEdgeCurl, settings.apiKey);
     case ServiceProvider.naver:
       validateNaverSettings(settings);
       return new NaverBooksApi(settings.naverClientId, settings.naverClientSecret);

--- a/src/apis/google_books_api.test.ts
+++ b/src/apis/google_books_api.test.ts
@@ -49,7 +49,7 @@ describe('Book creation', () => {
     canonicalVolumeLink: 'https://play.google.com/store/books/details?id=QVjPsd1UukEC',
   };
 
-  const api: GoogleBooksApi = new GoogleBooksApi('default');
+  const api: GoogleBooksApi = new GoogleBooksApi('default', true);
   const book: Book = api.createBookItem(volumeInfo);
 
   it('Title', () => {
@@ -106,5 +106,18 @@ describe('Book creation', () => {
 
   it('ISBN 13', () => {
     expect(book.isbn13).toEqual(volumeInfo.industryIdentifiers[1].identifier);
+  });
+
+  it('Enables Edge curl', () => {
+    expect(book.coverUrl).toContain('&edge=curl');
+    expect(book.coverSmallUrl).toContain('&edge=curl');
+  });
+
+  it('Disables Edge curl', () => {
+    const api: GoogleBooksApi = new GoogleBooksApi('default', false);
+    const book: Book = api.createBookItem(volumeInfo);
+
+    expect(book.coverUrl).not.toContain('&edge=curl');
+    expect(book.coverSmallUrl).not.toContain('&edge=curl');
   });
 });

--- a/src/apis/google_books_api.ts
+++ b/src/apis/google_books_api.ts
@@ -8,6 +8,7 @@ export class GoogleBooksApi implements BaseBooksApiImpl {
 
   constructor(
     private readonly localePreference: string,
+    private readonly enableCoverImageEdgeCurl: boolean,
     private readonly apiKey?: string,
   ) {}
 
@@ -64,8 +65,8 @@ export class GoogleBooksApi implements BaseBooksApiImpl {
       categories: item.categories,
       publisher: item.publisher,
       totalPage: item.pageCount,
-      coverUrl: item.imageLinks?.thumbnail ?? '',
-      coverSmallUrl: item.imageLinks?.smallThumbnail ?? '',
+      coverUrl: this.setCoverImageEdgeCurl(item.imageLinks?.thumbnail ?? '', this.enableCoverImageEdgeCurl),
+      coverSmallUrl: this.setCoverImageEdgeCurl(item.imageLinks?.smallThumbnail ?? '', this.enableCoverImageEdgeCurl),
       publishDate: item.publishedDate || '',
       description: item.description,
       link: item.canonicalVolumeLink || item.infoLink,
@@ -97,6 +98,12 @@ export class GoogleBooksApi implements BaseBooksApiImpl {
 
   public formatList(list?: string[]): string {
     return list && list.length > 1 ? list.map(item => item.trim()).join(', ') : list?.[0] ?? '';
+  }
+
+  private setCoverImageEdgeCurl(url: string, enabled: boolean): string {
+    // Edge curl is included in the cover image URL parameters by default,
+    // so we need to remove it if it's disabled
+    return enabled ? url : url.replace('&edge=curl', '');
   }
 
   static convertGoogleBookImageURLSize(url: string, zoom: number) {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -32,6 +32,7 @@ export interface BookSearchPluginSettings {
   openPageOnCompletion: boolean;
   showCoverImageInSearch: boolean;
   enableCoverImageSave: boolean;
+  enableCoverImageEdgeCurl: boolean;
   coverImagePath: string;
   askForLocale: boolean;
 }
@@ -52,6 +53,7 @@ export const DEFAULT_SETTINGS: BookSearchPluginSettings = {
   openPageOnCompletion: true,
   showCoverImageInSearch: false,
   enableCoverImageSave: false,
+  enableCoverImageEdgeCurl: true,
   coverImagePath: '',
   askForLocale: true,
 };
@@ -162,6 +164,8 @@ export class BookSearchSettingTab extends PluginSettingTab {
     let serviceProviderExtraSettingButton: HTMLElement;
     // eslint-disable-next-line prefer-const
     let preferredLocaleDropdownSetting: Setting;
+    // eslint-disable-next-line prefer-const
+    let coverImageEdgeCurlToggleSetting: Setting;
     const hideServiceProviderExtraSettingButton = () => {
       serviceProviderExtraSettingButton.addClass('book-search-plugin__hide');
     };
@@ -178,15 +182,28 @@ export class BookSearchSettingTab extends PluginSettingTab {
         preferredLocaleDropdownSetting.settingEl.removeClass('book-search-plugin__hide');
       }
     };
+    const hideCoverImageEdgeCurlToggle = () => {
+      if (coverImageEdgeCurlToggleSetting !== undefined) {
+        coverImageEdgeCurlToggleSetting.settingEl.addClass('book-search-plugin__hide');
+      }
+    };
+    const showCoverImageEdgeCurlToggle = () => {
+      if (coverImageEdgeCurlToggleSetting !== undefined) {
+        coverImageEdgeCurlToggleSetting.settingEl.removeClass('book-search-plugin__hide');
+      }
+    };
+
     const toggleServiceProviderExtraSettings = (
       serviceProvider: ServiceProvider = this.plugin.settings?.serviceProvider,
     ) => {
       if (serviceProvider === ServiceProvider.naver) {
         showServiceProviderExtraSettingButton();
         hideServiceProviderExtraSettingDropdown();
+        hideCoverImageEdgeCurlToggle();
       } else {
         hideServiceProviderExtraSettingButton();
         showServiceProviderExtraSettingDropdown();
+        showCoverImageEdgeCurlToggle();
       }
     };
     new Setting(containerEl)
@@ -259,6 +276,16 @@ export class BookSearchSettingTab extends PluginSettingTab {
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.askForLocale).onChange(async value => {
           this.plugin.settings.askForLocale = value;
+          await this.plugin.saveSettings();
+        }),
+      );
+
+    coverImageEdgeCurlToggleSetting = new Setting(containerEl)
+      .setName('Enable Cover Image Edge Curl Effect')
+      .setDesc('Toggle to show or hide page curl effect in cover images.')
+      .addToggle(toggle =>
+        toggle.setValue(this.plugin.settings.enableCoverImageEdgeCurl).onChange(async value => {
+          this.plugin.settings.enableCoverImageEdgeCurl = value;
           await this.plugin.saveSettings();
         }),
       );


### PR DESCRIPTION
Thanks for this plugin!

This PR adds a new check box to the settings to enable or disable the (rather unfortunate) "page curl" effect that's added by default to the bottom-right of cover images from the Google Books API.

The new setting:

![Screenshot 2024-09-03 at 20 44 18 of Obsidian - arabesque - Vault - Obsidian v1 6 7@2x](https://github.com/user-attachments/assets/a66fafab-87e1-43c4-a557-53cda4d1fd1f)

Sample cover with setting enabled:

<img src="https://books.google.com/books/content?id=QVjPsd1UukEC&printsec=frontcover&img=1&zoom=5&edge=curl&imgtk=AFLRE73bxh9ISs_hCP3iFSQQYhCYhYzF94fr4-iOEnjpXWXNIrz9C99HwbiJ_Zd4SG9dsbtuiEYOf5RbThhzxQwfmp-RuF5Tq7A6v8HQRI9MPuNPnVJ4yDUgx_mwIqHIPjGI4xfkcoiC&source=gbs_api">

Sample cover with setting disabled:

<img src="https://books.google.com/books/content?id=QVjPsd1UukEC&printsec=frontcover&img=1&zoom=5&imgtk=AFLRE73bxh9ISs_hCP3iFSQQYhCYhYzF94fr4-iOEnjpXWXNIrz9C99HwbiJ_Zd4SG9dsbtuiEYOf5RbThhzxQwfmp-RuF5Tq7A6v8HQRI9MPuNPnVJ4yDUgx_mwIqHIPjGI4xfkcoiC&source=gbs_api">

The default is "enabled" so as not to change the plugin's existing behavior. (Though I'd argue that "disabled" might be a better default since the effect is so middling.)

The PR includes new tests for the feature, and implements conditional rendering for the option in the settings page since it does not apply when Naver is the API source.

Implementation notes:

- The implementation for conditional rendering of the settings entry is a bit verbose, but matches the plugin's existing approach to conditional rendering.

- The plugin's existing settings menu items are inconsistently cased, and don't follow the [Obsidian style guide](https://help.obsidian.md/Contributing+to+Obsidian/Style+guide#Sentence+case), but I followed the "Title Case" precedent used by other image-related settings.

- The new setting is ordered before the "Enable Cover Image Save" setting since it applies to the template values of _both_  `{{coverUrl}}` and `{{localCoverImage}}`.
